### PR TITLE
Fix imports for module execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Run the main script with root privileges to access CAN:
 sudo python3 -m src.main
 ```
 
+Make sure to use the `-m` flag so Python runs the package modules correctly.
+
 Move the left joystick to control motor speed. The encoder position is displayed in degrees in the console.
 
 ## Notes

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import time
-from xbox_controller import XboxController
-from talonsrx_controller import TalonSRXController
+# Use package-relative imports so running as a module works
+from .xbox_controller import XboxController
+from .talonsrx_controller import TalonSRXController
 
 
 def main():


### PR DESCRIPTION
## Summary
- use package-relative imports in `src/main.py`
- clarify README about `-m` usage

## Testing
- `python3 -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68435e00aaac832ca60c58fcba20cca6