### PR TITLE
Improve README and handle missing pygame

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,14 @@ This project demonstrates controlling a CTRE Talon SRX motor controller with a B
 - An Xbox controller connected via USB or Bluetooth
 - CTRE Talon SRX with BAG motor and Versa Planetary encoder wired to the CAN bus
 
-Install Python dependencies (including RobotPy's CTRE bindings):
+Install Python dependencies (including RobotPy's CTRE bindings). When running
+the program with `sudo`, the packages must be available for the root
+environment as well:
 
 ```bash
 pip install -r requirements.txt
+# or, if running the program with sudo
+sudo pip install -r requirements.txt
 ```
 
 ## Running
@@ -26,6 +30,8 @@ Run the main script with root privileges to access CAN:
 ```bash
 sudo python3 -m src.main
 ```
+
+Make sure to use the `-m` flag so Python runs the package modules correctly.
 
 Move the left joystick to control motor speed. The encoder position is displayed in degrees in the console.
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import time
-from xbox_controller import XboxController
-from talonsrx_controller import TalonSRXController
+# Use package-relative imports so running as a module works
+from .xbox_controller import XboxController
+from .talonsrx_controller import TalonSRXController
 
 
 def main():

--- a/src/xbox_controller.py
+++ b/src/xbox_controller.py
@@ -1,4 +1,9 @@
-import pygame
+try:
+    import pygame
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        "pygame is required for the Xbox controller. Install dependencies via 'pip install -r requirements.txt' (use sudo if necessary)."
+    ) from e
 
 class XboxController:
     def __init__(self):


### PR DESCRIPTION
## Summary
- document installing requirements with sudo if needed
- fail gracefully when pygame isn't installed

## Testing
- `python3 -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68435e00aaac832ca60c58fcba20cca6