### PR TITLE
Improve CTRE dependency message

### DIFF
--- a/src/talonsrx_controller.py
+++ b/src/talonsrx_controller.py
@@ -1,4 +1,9 @@
-import ctre
+try:
+    import ctre
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        "robotpy-ctre is required for the Talon SRX controller. Install dependencies via 'pip install -r requirements.txt' (use sudo if necessary)."
+    ) from e
 
 
 class TalonSRXController:


### PR DESCRIPTION
## Summary
- handle missing CTRE bindings with a helpful error

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6843a8f80cac832c8a840c7125b2aaeb